### PR TITLE
Improvements

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,12 +1,9 @@
-use crate::{DefaultKey, EnrError, EnrKey, EnrPublicKey, EnrRaw, NodeId, MAX_ENR_SIZE};
+use crate::{Enr, EnrError, EnrKey, EnrPublicKey, NodeId, MAX_ENR_SIZE};
 use rlp::RlpStream;
 use std::{collections::BTreeMap, marker::PhantomData, net::IpAddr};
 
-/// The default builder of ENR records which uses the standard signing algorithms.
-pub type EnrBuilder = EnrBuilderRaw<DefaultKey>;
-
 ///! The raw builder for generating ENR records with arbitrary signing algorithms.
-pub struct EnrBuilderRaw<K: EnrKey> {
+pub struct EnrBuilder<K: EnrKey> {
     /// The identity scheme used to build the ENR record.
     id: String,
 
@@ -20,12 +17,12 @@ pub struct EnrBuilderRaw<K: EnrKey> {
     phantom: PhantomData<K>,
 }
 
-impl<K: EnrKey> EnrBuilderRaw<K> {
+impl<K: EnrKey> EnrBuilder<K> {
     /// Constructs a minimal `EnrBuilder` providing only a sequence number.
     /// Currently only supports the id v4 scheme and therefore disallows creation of any other
     /// scheme.
     pub fn new(id: impl Into<String>) -> Self {
-        EnrBuilderRaw {
+        EnrBuilder {
             id: id.into(),
             seq: 1,
             content: BTreeMap::new(),
@@ -128,7 +125,7 @@ impl<K: EnrKey> EnrBuilderRaw<K> {
     }
 
     /// Constructs an ENR from the ENRBuilder struct.
-    pub fn build(&mut self, key: &K) -> Result<EnrRaw<K>, EnrError> {
+    pub fn build(&mut self, key: &K) -> Result<Enr<K>, EnrError> {
         // add the identity scheme to the content
         if self.id != "v4" {
             return Err(EnrError::UnsupportedIdentityScheme);
@@ -147,7 +144,7 @@ impl<K: EnrKey> EnrBuilderRaw<K> {
             return Err(EnrError::ExceedsMaxSize);
         }
 
-        Ok(EnrRaw {
+        Ok(Enr {
             seq: self.seq,
             node_id: NodeId::from(key.public()),
             content: self.content.clone(),

--- a/src/enr-cli.rs
+++ b/src/enr-cli.rs
@@ -2,7 +2,7 @@
 //! the future.
 
 use clap::{App, Arg};
-use enr::Enr;
+use enr::{DefaultKey, Enr};
 
 fn main() {
     // Parse the CLI parameters.
@@ -52,7 +52,7 @@ fn main() {
 
     let enr = matches
         .value_of("enr")
-        .map(|enr| enr.parse::<Enr>().expect("Invalid ENR"))
+        .map(|enr| enr.parse::<Enr<DefaultKey>>().expect("Invalid ENR"))
         .expect("Must supply an ENR");
 
     if matches.is_present("read") {
@@ -60,7 +60,7 @@ fn main() {
     }
 }
 
-fn print_enr(enr: Enr) {
+fn print_enr(enr: Enr<DefaultKey>) {
     println!("ENR Read");
     println!("Sequence No: {}", enr.seq());
     println!("Node ID: {}", enr.node_id());

--- a/src/node_id.rs
+++ b/src/node_id.rs
@@ -6,7 +6,7 @@ use sha3::{Digest, Keccak256};
 
 type RawNodeId = [u8; 32];
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 /// The NodeId of an ENR (a 32 byte identifier).
 pub struct NodeId {
     raw: RawNodeId,


### PR DESCRIPTION
* `EnrRaw` is now `Enr` as `DefaultKey` is not necessarily the best universal signer implementation.
* `impl<K: ?Clone> Clone for Enr<K>`
* `impl Copy for NodeId`